### PR TITLE
Fix LLM chat route

### DIFF
--- a/components/llm_service/src/routes/chat.py
+++ b/components/llm_service/src/routes/chat.py
@@ -271,7 +271,7 @@ async def user_chat_generate(chat_id: str, gen_config: LLMGenerateModel):
   llm_type = user_chat.llm_type
 
   try:
-    response = await llm_chat(prompt, llm_type, user_chat)
+    response = await llm_chat(prompt, llm_type)
 
     # save chat history
     user_chat.update_history(prompt, response)


### PR DESCRIPTION
Removes the 3rd positional argument from the call to `llm_chat()` in the `/{chat_id}/generate` route, which caused follow-up chat messages to result in an error.