### PR TITLE
Prevent managed cert from deploying if no domains

### DIFF
--- a/terraform/modules/ingress_gce/main.tf
+++ b/terraform/modules/ingress_gce/main.tf
@@ -44,6 +44,7 @@ resource "google_compute_global_address" "ingress_ip_address" {
 }
 
 resource "google_compute_managed_ssl_certificate" "managed_certificate" {
+  count = ((length(var.domains) == 1) && (var.domains[0] == "None")) ? 0 : 1
   provider = google-beta
 
   name = var.managed_cert_name


### PR DESCRIPTION
When applying on 3-gke-ingress using `sb infra apply 3-gke-ingress`, an error will occur if the user did not specify a domain during the [Add an HTTP Load balancer with DNS domain](https://github.com/GoogleCloudPlatform/core-solution-services/tree/60ccde36fa0ec7f0d915952ba27bbb7ea998bb01#add-an-http-load-balancer-with-dns-domain) step. This prevents the resource, google_compute_managed_ssl_certificate.managed_certificate from beind deployed. 

The current error is:
``` │ Error: Error creating ManagedSslCertificate: googleapi: Error 400: Invalid value for field 'resource.managed.domains[0]': 'None'. Invalid domain name specified., invalid
│ 
│   with module.ingress_gce.google_compute_managed_ssl_certificate.managed_certificate,
│   on ../../modules/ingress_gce/main.tf line 46, in resource "google_compute_managed_ssl_certificate" "managed_certificate":
│   46: resource "google_compute_managed_ssl_certificate" "managed_certificate" {
│ 
╵
Error when running command:  terraform apply   (working_dir=./terraform/stages/3-gke-ingress) ```